### PR TITLE
Fixed typo in submodule name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then you can use the roles from the collection in your playbooks:
     
       roles:
         - php
-        - role: php-versions
+        - role: php_versions
           vars:
             php_version: '7.3'
 


### PR DESCRIPTION
Same issue as corrected in https://github.com/geerlingguy/ansible-collection-php_roles/issues/5