### PR TITLE
Checkout submodules when releasing to Ansible Galaxy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ansible_collections/geerlingguy/php_roles
+          submodules: recursive
 
       - name: Set up Python 3.
         uses: actions/setup-python@v2
@@ -52,6 +53,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ansible_collections/geerlingguy/php_roles
+          submodules: recursive
 
       - name: Set up Python 3.
         uses: actions/setup-python@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ansible_collections/geerlingguy/php_roles
+          submodules: recursive
 
       - name: Set up Python 3.
         uses: actions/setup-python@v2


### PR DESCRIPTION
The [2.0.0 tarball in Ansible galaxy](https://galaxy.ansible.com/download/geerlingguy-php_roles-2.0.0.tar.gz) has empty roles.  I believe this is because when the GitHub Action runs, it does not checkout submodules.  According to my google-fu, this seems like the way to ensure we checkout submodules in this repository.

This should fix #12 